### PR TITLE
Update appsweep version to fix build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.guardsquare.appsweep" version "0.1.2"
+  id "com.guardsquare.appsweep" version "latest.release"
 }
 
 apply plugin: 'com.android.application'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath 'com.android.tools.build:gradle:7.3.1'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This changes the appsweep version to `latest.release` to make PIVAA work out-of-the box, as the previous version was not found by Gradle and ensuring that the latest version is used. Also includes a Gradle version update to ensure that the `latest.release` placeholder works properly.